### PR TITLE
Implemented workaround for creation functions that return concrete component types

### DIFF
--- a/src/component/define_test.go
+++ b/src/component/define_test.go
@@ -2,12 +2,28 @@ package component_test
 
 import (
 	"assert"
+	"component"
 	"controls"
 	"ctx"
 	"opts"
 	"testing"
 	. "ui"
 )
+
+// fooStruct is a component definition.
+type fooStruct struct {
+	component.Component
+}
+
+// newFoo creates and returns an instance of fooStruct.
+func newFoo() *fooStruct {
+	return &fooStruct{}
+}
+
+// foo is a component definition. Sadly, we must wrap concrete constructors
+// with a function that returns a Displayable :barf:
+var foo = component.Define("foo",
+	func() Displayable { return newFoo() })
 
 func TestComponentFactory(t *testing.T) {
 	t.Run("Default State", func(t *testing.T) {
@@ -60,8 +76,8 @@ func TestComponentFactory(t *testing.T) {
 	})
 
 	t.Run("Custom type", func(t *testing.T) {
-		fake := controls.Fake(ctx.New())
-		if fake == nil {
+		instance := foo(ctx.New())
+		if instance == nil {
 			t.Error("Expected builder to return new component")
 		}
 	})

--- a/src/controls/nano_window.go
+++ b/src/controls/nano_window.go
@@ -154,13 +154,14 @@ func (c *NanoWindowComponent) LayoutDrawAndPaint() {
 	c.SwapWindowBuffers()
 }
 
-func NewNanoWindow() ui.Displayable {
+func NewNanoWindow() *NanoWindowComponent {
 	win := &NanoWindowComponent{}
 	win.SetTitle(ui.DefaultWindowTitle)
 	return win
 }
 
-var NanoWindow = component.Define("NanoWindow", NewNanoWindow,
+var NanoWindow = component.Define("NanoWindow",
+	func() ui.Displayable { return NewNanoWindow() },
 	opts.LayoutType(ui.VerticalFlowLayoutType),
 	opts.Width(ui.DefaultWindowWidth),
 	opts.Height(ui.DefaultWindowHeight))

--- a/src/controls/test_helper.go
+++ b/src/controls/test_helper.go
@@ -16,12 +16,13 @@ type FakeComponent struct {
 	component.Component
 }
 
-func NewFake() ui.Displayable {
+func NewFake() *FakeComponent {
 	return &FakeComponent{}
 }
 
 // Create a new factory using our component creation function reference.
-var Fake = component.Define("Fake", NewFake)
+var Fake = component.Define("Fake",
+	func() ui.Displayable { return NewFake() })
 
 func TestMain(m *testing.M) {
 	// This is required if any test uses a OpenTestWindow


### PR DESCRIPTION
Fixed #221  (sort of)

We cannot easily accept any arbitrary function types.

Here's a playground that shows what I'd like to do, any tips are appreciated:

https://play.golang.org/p/MrP0_ZKI7sT