### PR TITLE
Improved laggy window resize on Linux

### DIFF
--- a/pkg/env/glfw/window.go
+++ b/pkg/env/glfw/window.go
@@ -174,9 +174,7 @@ func (win *window) initGl() {
 		panic(err)
 	}
 
-	// Thought we needed this, but it looks like Nanovgo might be handling
-	// this behind the scenes?
-	// gl.Viewport(0, 0, int32(win.Width()), int32(win.Height()))
+	gl.Viewport(0, 0, int32(win.Width()), int32(win.Height()))
 }
 
 func (win *window) initInput() {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -65,7 +65,6 @@ func (s *Scheduler) Listen() {
 
 func (s *Scheduler) windowResizedHandler(e events.Event) {
 	s.shouldRender = true
-	s.frameHandler(false)
 }
 
 func (s *Scheduler) frameHandler(pollEvents bool) bool {


### PR DESCRIPTION
Window resize on Linux no longer slowly walks toward correct dimensions, but quickly displays the expected size.

Unfortunately, there are visible artifacts during the drag/resize that should be investigated further.

Updated the event handling of resize events to no longer force a full tree render as the window is scaled.